### PR TITLE
chore: disable minification

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	"scripts": {
 		"analyze": "npx biome ci ./src",
 		"fix": "npx biome check --write ./src public/index.html public/index.css",
-		"build": "npx esbuild --bundle --outdir=public/dist --minify --keep-names src/index.ts",
+		"build": "npx esbuild --bundle --outdir=public/dist --keep-names src/index.ts",
 		"typecheck": "npx tsc",
 		"test": "echo not implemented yet",
 		"watch": "npx esbuild src/index.ts --bundle --outdir=public/dist --watch --sourcemap --keep-names"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
 		"build": "npx esbuild --bundle --outdir=public/dist --keep-names src/index.ts",
 		"typecheck": "npx tsc",
 		"test": "echo not implemented yet",
-		"watch": "npx esbuild src/index.ts --bundle --outdir=public/dist --watch --sourcemap --keep-names"
+		"watch": "npx esbuild --bundle --outdir=public/dist --keep-names --sourcemap --watch src/index.ts"
 	}
 }


### PR DESCRIPTION
This caused complications with the way command descriptions where generated, which rely on the exact function signiture