### PR TITLE
feat: add `intro` command and autoplay on terminal boot

### DIFF
--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -6,7 +6,7 @@ import { Component } from './litutil/Component.ts';
 import { configService } from './services/config.ts';
 import { parseCommand } from './services/parse-command.ts';
 import type { TerminalInput } from './TerminalInput.ts';
-import { commandNotFound, findCommand, helpCommands } from './terminal/commands.ts';
+import { commandNotFound, commands, findCommand, helpCommands } from './terminal/commands.ts';
 import type { Command, TerminalResponse } from './terminal/terminal.ts';
 
 interface CommandResponse {
@@ -110,6 +110,7 @@ export class Terminal extends Component {
 	#suggestionTimeout: number | null = null;
 	#resolvePromptResponse: ((value: string) => void) | null = null;
 	#resizeObserver: ResizeObserver | null = null;
+	#startupCommand: Command | null = commands.intro;
 
 	@state() inputDisabled: boolean = false;
 	@state() hidden: boolean = false;
@@ -269,6 +270,10 @@ export class Terminal extends Component {
 			this.terminalWidth = entries[0].contentRect.width;
 		});
 		this.#resizeObserver.observe(this.shadowRoot?.host as Element);
+
+		if (this.#startupCommand) {
+			this.executeCommand(this.#startupCommand);
+		}
 	}
 
 	renderResponse(response: Response) {

--- a/src/TerminalResponseItem.ts
+++ b/src/TerminalResponseItem.ts
@@ -158,9 +158,6 @@ export class TerminalResponseItem extends Component {
   			font-weight: lighter;
 			}
 
-			&.command {
-				color: #8be9fd;
-			}
 
 			&.config-key {
 				color: #ff79c6;

--- a/src/terminal/commands.ts
+++ b/src/terminal/commands.ts
@@ -5,6 +5,7 @@ import contact from './commands/contact.ts';
 import exit from './commands/exit.ts';
 import github from './commands/github.ts';
 import help from './commands/help.ts';
+import intro from './commands/intro.ts';
 import mh from './commands/mh.ts';
 import pong from './commands/pong/pong.ts';
 import snake from './commands/snake/snake.ts';
@@ -14,7 +15,7 @@ import whoami from './commands/whoami.ts';
 import { type Command, highlight, text } from './terminal.ts';
 
 // biome-ignore format: Force vertical list for easier reading / reordering
-const commands = [
+const commands = {
 	who,
 	tech,
 	career,
@@ -28,13 +29,16 @@ const commands = [
 	mh,
 	pong,
 	snake,
-];
+	intro,
+} as const;
 
-const visibleCommands = commands.filter(cmd => !cmd.isHidden);
-const helpCommands = commands.filter(cmd => !cmd.noHelp);
+const allCommands: Command[] = Object.values(commands);
+
+const visibleCommands = allCommands.filter(cmd => !cmd.isHidden);
+const helpCommands = allCommands.filter(cmd => !cmd.noHelp);
 
 const findCommand = (name: string): Command | undefined => {
-	return commands.find(cmd => cmd.name.toLowerCase() === name.toLowerCase());
+	return allCommands.find(cmd => cmd.name.toLowerCase() === name.toLowerCase());
 };
 
 const commandNotFound = (command: string) => [
@@ -42,4 +46,4 @@ const commandNotFound = (command: string) => [
 	text(` ${command}: command not found.`),
 ];
 
-export { commandNotFound, findCommand, helpCommands, visibleCommands };
+export { commandNotFound, findCommand, helpCommands, visibleCommands, commands };

--- a/src/terminal/commands/intro.ts
+++ b/src/terminal/commands/intro.ts
@@ -12,7 +12,7 @@ const logo = String.raw`
 const logoLines = logo
 	.split('\n')
 	.filter(line => line.trim() !== '')
-	.map(line => line.replaceAll(' ', '\u00A0'))
+	.map(line => line.replace(/ /g, '\u00A0'))
 	.flatMap(line => [text(line), linebreak()]);
 
 const intro: Command = {

--- a/src/terminal/commands/intro.ts
+++ b/src/terminal/commands/intro.ts
@@ -1,0 +1,47 @@
+import { type Command, indentation, linebreak, mentionCommandName, text } from '../terminal.ts';
+
+const logo = String.raw`
+ _____ ______   ___  ___
+|\   _ \  _   \|\  \|\  \
+\ \  \\\__\ \  \ \  \\\  \
+ \ \  \\|__| \  \ \   __  \
+  \ \  \    \ \  \ \  \ \  \
+   \ \__\    \ \__\ \__\ \__\
+    \|__|     \|__|\|__|\|__|
+`;
+const logoLines = logo
+	.split('\n')
+	.filter(line => line.trim() !== '')
+	.map(line => line.replaceAll(' ', '\u00A0'))
+	.flatMap(line => [text(line), linebreak()]);
+
+const intro: Command = {
+	name: 'intro',
+	description: 'Introduction to the terminal',
+	prepare: terminal => () => [
+		...logoLines,
+		linebreak(1),
+		text('Welcome to my terminal! Here are some commands you can try:'),
+		indentation(1, [
+			text('- '),
+			mentionCommandName(terminal, 'who'),
+			text(': Learn more about me'),
+			linebreak(),
+			text('- '),
+			mentionCommandName(terminal, 'career'),
+			text(': See what I have done so far'),
+			linebreak(),
+			text('- '),
+			mentionCommandName(terminal, 'pong'),
+			text(': Play a game of pong'),
+		]),
+		linebreak(1),
+		text('To get a full list of commands, type '),
+		mentionCommandName(terminal, 'help'),
+		text('.'),
+		linebreak(1),
+		text('Have fun exploring!'),
+	],
+};
+
+export default intro;

--- a/src/terminal/commands/snake/snake.ts
+++ b/src/terminal/commands/snake/snake.ts
@@ -3,7 +3,7 @@ import { type Command, component, indentation, linebreak, text } from '../../ter
 
 const snake: Command = {
 	name: 'snake',
-	description: 'Play a game of Snake',
+	description: 'Play a game of snake',
 	prepare(terminal) {
 		return () => {
 			terminal.disableInput();


### PR DESCRIPTION
This pull request introduces an introductory command that displays a welcome message and helpful tips when the terminal starts. It also refactors the command system to use an object for easier access and management of commands. Additionally, some minor improvements and cleanups are included.

**Introductory experience:**
* Added a new `intro` command in `src/terminal/commands/intro.ts` that displays an ASCII logo and a welcome message with suggested commands. This command is automatically executed when the terminal loads, providing users with guidance on how to get started. [[1]](diffhunk://#diff-bb2c9f74d8eb53bed729c06e5a66ff9fcc767e80dd3b274e0557c305926a5357R1-R47) [[2]](diffhunk://#diff-ff2de3817e53128f892fcce3d7640752cab4e089a0a3e0777c38d827ac66493bR113) [[3]](diffhunk://#diff-ff2de3817e53128f892fcce3d7640752cab4e089a0a3e0777c38d827ac66493bR273-R276)

**Command system refactor:**
* Changed the `commands` export in `src/terminal/commands.ts` from an array to an object, allowing direct access to commands by name and simplifying command lookups. Updated related logic to use `Object.values(commands)` where arrays are needed. [[1]](diffhunk://#diff-ff2ba10a454644c4c1c5ccaf6b09a0364a8834de9083b23717e981bf7fb97432L17-R18) [[2]](diffhunk://#diff-ff2ba10a454644c4c1c5ccaf6b09a0364a8834de9083b23717e981bf7fb97432L31-R49) [[3]](diffhunk://#diff-ff2de3817e53128f892fcce3d7640752cab4e089a0a3e0777c38d827ac66493bL9-R9) [[4]](diffhunk://#diff-ff2ba10a454644c4c1c5ccaf6b09a0364a8834de9083b23717e981bf7fb97432R8)

**Minor improvements:**
* Updated the description of the `snake` command for consistency ("Play a game of snake" instead of "Play a game of Snake").
* Removed an unused CSS class selector for `.command` in `TerminalResponseItem` for code cleanliness.