### PR TITLE
fix: points being awarded multiple times when hitting the paddle on t…

### DIFF
--- a/src/terminal/commands/pong/strategies.ts
+++ b/src/terminal/commands/pong/strategies.ts
@@ -43,6 +43,8 @@ abstract class GameStrategy {
 }
 
 class SinglePlayerStrategy extends GameStrategy {
+	protected _lastReflectX: 'left' | 'right' | null = null;
+
 	resetBall() {
 		this.state.$.ball.position = {
 			x: this.config.$.field.width / 2,
@@ -109,14 +111,36 @@ class SinglePlayerStrategy extends GameStrategy {
 		}
 
 		if (this.game.hasHitRightPaddle() || this.game.isOutOfBoundsRight()) {
-			this.game.reflectBallX();
+			this.reflectBallX();
 			return;
 		}
 
 		if (this.game.hasHitLeftPaddle()) {
-			this.state.$.playerLeft.score++;
-			this.game.reflectBallX();
+			const reflected = this.reflectBallX();
+			if (reflected) {
+				this.state.$.playerLeft.score++;
+			}
 		}
+	}
+
+	reflectBallX(): boolean {
+		// Prevent multiple reflections on the same paddle hit
+		if (this._lastReflectX === 'left' && this.game.hasHitLeftPaddle()) {
+			return false;
+		} else if (this._lastReflectX === 'right' && this.game.hasHitRightPaddle()) {
+			return false;
+		}
+
+		if (this.game.hasHitLeftPaddle()) {
+			this._lastReflectX = 'left';
+		} else if (this.game.hasHitRightPaddle()) {
+			this._lastReflectX = 'right';
+		} else {
+			this._lastReflectX = null;
+		}
+
+		this.game.reflectBallX();
+		return true;
 	}
 
 	tick(deltaTime: number) {
@@ -141,6 +165,7 @@ class SinglePlayerStrategy extends GameStrategy {
 	}
 
 	continue(): void {
+		this._lastReflectX = null;
 		switch (this.state.$.phase) {
 			case 'initial':
 			case 'game-over':


### PR DESCRIPTION
This pull request improves the ball reflection logic in the single-player Pong game strategy to prevent multiple reflections from being triggered by a single paddle hit. The changes introduce state tracking to ensure the ball only reflects once per paddle contact and resets this state appropriately.

**Ball reflection logic improvements:**

* Added a `_lastReflectX` property to the `SinglePlayerStrategy` class to track the last paddle (left or right) that reflected the ball, preventing multiple reflections from a single hit.
* Replaced direct calls to `this.game.reflectBallX()` with a new `reflectBallX()` method that uses `_lastReflectX` to ensure only one reflection per paddle hit. This method returns a boolean indicating whether a reflection occurred.
* Updated scoring logic to increment the left player's score only when a valid reflection occurs on the left paddle.
* Reset `_lastReflectX` to `null` in the `continue()` method to ensure correct state when the game resumes.…he upper or lower end